### PR TITLE
Php update (#789)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,9 @@
             "port": 9000,
             "pathMappings": {
                 "/app": "${workspaceRoot}"
+            },
+            "xdebugSettings": {
+                "max_children": 200
             }
         },
         {

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN tar -xzvf $PHP_BUILDPACK_VERSION.tar.gz -C /tmp/buildpack/php --strip-compon
 RUN /tmp/buildpack/php/bin/compile /app /tmp/build_cache /tmp/env
 
 # Set up xdebug
-RUN $HEROKU_PHP_BIN/pecl install channel://pecl.php.net/xdebug-2.4.0
+RUN $HEROKU_PHP_BIN/pecl install channel://pecl.php.net/xdebug-2.6.1

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "~5.6.12",
+        "php": "~7.2",
         "ext-redis": "*",
         "ext-soap": "*",
         "sentry/sentry": "^1.9"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68ec110aab4b7d444c66d090d7252e4a",
+    "content-hash": "5a178c03f9c79dce5024bf519b6fce5f",
     "packages": [
         {
             "name": "sentry/sentry",
-            "version": "1.9.0",
+            "version": "1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "c90567d78382b803e563939654d1563ddee61707"
+                "reference": "6b4c80ee1f5d9d5ab5bae949f4eb5d758a0bf64b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/c90567d78382b803e563939654d1563ddee61707",
-                "reference": "c90567d78382b803e563939654d1563ddee61707",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/6b4c80ee1f5d9d5ab5bae949f4eb5d758a0bf64b",
+                "reference": "6b4c80ee1f5d9d5ab5bae949f4eb5d758a0bf64b",
                 "shasum": ""
             },
             "require": {
@@ -44,7 +44,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -68,7 +68,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2018-05-03T12:06:52+00:00"
+            "time": "2018-08-18T19:41:03+00:00"
         }
     ],
     "packages-dev": [],
@@ -78,7 +78,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~5.6.12",
+        "php": "~7.2",
         "ext-redis": "*",
         "ext-soap": "*"
     },

--- a/local-development/local_php.ini
+++ b/local-development/local_php.ini
@@ -9,7 +9,7 @@ opcache.enable = 0
 
 ; Enable xdebug
 ; https://enrise.com/2018/02/debugging-php-with-xdebug/
-zend_extension=/app/.heroku/php/lib/php/extensions/no-debug-non-zts-20131226/xdebug.so
+zend_extension=/app/.heroku/php/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so
 xdebug.remote_enable = On
 xdebug.remote_connect_back = Off
 xdebug.remote_host = host.docker.internal

--- a/scripts/composer_update.sh
+++ b/scripts/composer_update.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm --interactive --tty --volume $PWD:/app composer update --ignore-platform-reqs --no-scripts

--- a/workbench/config/WorkbenchConfig.php
+++ b/workbench/config/WorkbenchConfig.php
@@ -60,7 +60,9 @@ class WorkbenchConfig {
             $envKey = str_replace("___DOT___", ".", $envKey);
         
             $envKeyParts = explode($configDelim, $envKey);
-        
+
+            $lastKey = end($envKeyParts);
+            reset($envKeyParts);
             foreach ($envKeyParts as $keyPart) {
                 if ($keyPart === $configNamespace) {
                     $point = &$this->config;
@@ -68,9 +70,13 @@ class WorkbenchConfig {
                 }
         
                 if (!isset($point[$keyPart])) {
-                    $point[$keyPart] = "";
+                    if ($keyPart === $lastKey) {
+                      $point[$keyPart] = "";
+                      } else {
+                        $point[$keyPart] = [];
+                      }
                 }
-        
+
                 $point = &$point[$keyPart];
             }
         


### PR DESCRIPTION
* initial push

* testing

* Updates the composer.json and composer.lock files to use php 7.1

* Adds new path for latest version of xdebug to docker file as well as php.ini. Adds ^7.2 for php as well as updates the composer lock file.

* Cleans up some minor differences in 2 files. A commented out testing phrase and redis version set back to Alpine

* adds logs for error on workbench config

* Update README.md

* Trying 3 params for workbench log

* Trying 3 params for workbench log

* Commented out workbench logs

* Error log with print_r

* Error log with print_r and bool

* Fixes php7 depricated string conversion. Replaces empty array with empty string.

* Cleans up whitespace

* php version set to ~7.2 from ^7.2

* Adds if block to prevent inf loop on default string vals

* Readme spaces cleaned up

* overrides.php reverted to original

* Adds composer_update.sh and updated composer lock

* Fixes workbenchconfig bug. Increases xdebug limits

* Code pulled from git for whitespace. Updated with config bug changes.

* Adds shebang to composer_update.sh

* end()/reset() pattern updated to end(array_values($array)) pattern

* Reverts back to end()/reset() for improved performance.